### PR TITLE
Correct NodeResourceTopology api version

### DIFF
--- a/manifests/crd-instance-example.yaml
+++ b/manifests/crd-instance-example.yaml
@@ -1,10 +1,9 @@
 ---
-apiVersion: topology.node.k8s.io/v1
+apiVersion: topology.node.k8s.io/v1alpha1
 kind: NodeResourceTopology
 metadata:
   name: node1
-topologyPolicies:
-  - singleNumaNode
+topologyPolicies: ["SingleNUMANode"]
 zones:
   - name: node-0
     type: Node

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   group: topology.node.k8s.io
   versions:
-    - name: v1
+    - name: v1alpha1
       served: true
       storage: true
       schema:


### PR DESCRIPTION
 - change from topology.node.k8s.io/v1 to topology.node.k8s.io/v1alpha1

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>