### PR TITLE
Fix bug in the NodeResourceTopology Custom Resource Definition

### DIFF
--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -48,7 +48,7 @@ spec:
                       properties:
                         name:
                           type: string
-                        type:
+                        value:
                           type: integer
                   attributes:
                     type: array
@@ -57,7 +57,7 @@ spec:
                       properties:
                         name:
                           type: string
-                        type:
+                        value:
                           type: string
   scope: Namespaced
   names:


### PR DESCRIPTION
Identified this bug while updating Node feature discovery
to the latest version of the noderesourcetopology-api

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>