### PR TITLE
Remove TopologyManagerPolicy

### DIFF
--- a/pkg/apis/topology/v1alpha1/types.go
+++ b/pkg/apis/topology/v1alpha1/types.go
@@ -5,17 +5,15 @@ import (
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
-type TopologyManagerPolicy string
-
 const (
-	// Constants of type TopologyManagerPolicy represent policy of the worker
+	// Constants of type string represent policy of the worker
 	// node's resource management component. It's TopologyManager in kubele.
 	// SingleNUMANodeContainerLevel represent single-numa-node policy of
 	// the TopologyManager
-	SingleNUMANodeContainerLevel TopologyManagerPolicy = "SingleNUMANodeContainerLevel"
+	SingleNUMANodeContainerLevel string = "SingleNUMANodeContainerLevel"
 	// SingleNUMANodePodLevel enables pod level resource counting, this policy assumes
 	// TopologyManager policy single-numa-node also was set on the node
-	SingleNUMANodePodLevel TopologyManagerPolicy = "SingleNUMANodePodLevel"
+	SingleNUMANodePodLevel string = "SingleNUMANodePodLevel"
 )
 
 // +genclient


### PR DESCRIPTION
And use string as type for the constants.

It helps to avoid unnecessary casting in scheduler plugin.

Signed-off-by: Alexey Perevalov <alexey.perevalov@huawei.com>