### PR TITLE
hack: add YEAR to boilerplate.go.txt

### DIFF
--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright YEAR The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This will be replaced with the current year by code generators.

Signed-off-by: Markus Lehtonen <markus.lehtonen@intel.com>