### PR TITLE
Change CostInfo.Value from int to int64

### DIFF
--- a/pkg/apis/topology/v1alpha1/types.go
+++ b/pkg/apis/topology/v1alpha1/types.go
@@ -57,7 +57,7 @@ type ResourceInfoList []ResourceInfo
 
 type CostInfo struct {
 	Name  string `json:"name"`
-	Value int    `json:"value"`
+	Value int64  `json:"value"`
 }
 type CostList []CostInfo
 


### PR DESCRIPTION
Makes the struct directly translatable to protobuf.