### PR TITLE
Change ZoneList into a slice of pointers

### DIFF
--- a/pkg/apis/topology/v1alpha1/types.go
+++ b/pkg/apis/topology/v1alpha1/types.go
@@ -51,7 +51,7 @@ type Zone struct {
 
 // ZoneList contains an array of Zone objects.
 // +protobuf=true
-type ZoneList []Zone
+type ZoneList []*Zone
 
 // ResourceInfo contains information about one resource type.
 // +protobuf=true

--- a/pkg/apis/topology/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/topology/v1alpha1/zz_generated.deepcopy.go
@@ -90,7 +90,11 @@ func (in *NodeResourceTopology) DeepCopyInto(out *NodeResourceTopology) {
 		in, out := &in.Zones, &out.Zones
 		*out = make(ZoneList, len(*in))
 		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(Zone)
+				(*in).DeepCopyInto(*out)
+			}
 		}
 	}
 }
@@ -222,7 +226,11 @@ func (in ZoneList) DeepCopyInto(out *ZoneList) {
 		in := &in
 		*out = make(ZoneList, len(*in))
 		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(Zone)
+				(*in).DeepCopyInto(*out)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Use a slice of pointers instead of slice of structs. This fixes an
impendance mismatch of "repeated Zone" field in 3rd party protobuf code
and ZoneList of this API.