### PR TITLE
NRT: fix missing tags

### DIFF
--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -15,7 +15,7 @@ spec:
     shortNames:
     - node-res-topo
     singular: noderesourcetopology
-  scope: cluster
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/pkg/apis/topology/v1alpha1/types.go
+++ b/pkg/apis/topology/v1alpha1/types.go
@@ -26,6 +26,7 @@ const (
 )
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster,shortName=node-res-topo
 

--- a/pkg/apis/topology/v1alpha1/types.go
+++ b/pkg/apis/topology/v1alpha1/types.go
@@ -27,7 +27,7 @@ const (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=cluster,shortName=node-res-topo
+// +kubebuilder:resource:scope=Cluster,shortName=node-res-topo
 
 // NodeResourceTopology describes node resources and their topology.
 type NodeResourceTopology struct {

--- a/pkg/generated/clientset/versioned/typed/topology/v1alpha1/fake/fake_noderesourcetopology.go
+++ b/pkg/generated/clientset/versioned/typed/topology/v1alpha1/fake/fake_noderesourcetopology.go
@@ -35,7 +35,6 @@ import (
 // FakeNodeResourceTopologies implements NodeResourceTopologyInterface
 type FakeNodeResourceTopologies struct {
 	Fake *FakeTopologyV1alpha1
-	ns   string
 }
 
 var noderesourcetopologiesResource = schema.GroupVersionResource{Group: "topology.node.k8s.io", Version: "v1alpha1", Resource: "noderesourcetopologies"}
@@ -45,8 +44,7 @@ var noderesourcetopologiesKind = schema.GroupVersionKind{Group: "topology.node.k
 // Get takes name of the nodeResourceTopology, and returns the corresponding nodeResourceTopology object, and an error if there is any.
 func (c *FakeNodeResourceTopologies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.NodeResourceTopology, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(noderesourcetopologiesResource, c.ns, name), &v1alpha1.NodeResourceTopology{})
-
+		Invokes(testing.NewRootGetAction(noderesourcetopologiesResource, name), &v1alpha1.NodeResourceTopology{})
 	if obj == nil {
 		return nil, err
 	}
@@ -56,8 +54,7 @@ func (c *FakeNodeResourceTopologies) Get(ctx context.Context, name string, optio
 // List takes label and field selectors, and returns the list of NodeResourceTopologies that match those selectors.
 func (c *FakeNodeResourceTopologies) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.NodeResourceTopologyList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(noderesourcetopologiesResource, noderesourcetopologiesKind, c.ns, opts), &v1alpha1.NodeResourceTopologyList{})
-
+		Invokes(testing.NewRootListAction(noderesourcetopologiesResource, noderesourcetopologiesKind, opts), &v1alpha1.NodeResourceTopologyList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -78,15 +75,13 @@ func (c *FakeNodeResourceTopologies) List(ctx context.Context, opts v1.ListOptio
 // Watch returns a watch.Interface that watches the requested nodeResourceTopologies.
 func (c *FakeNodeResourceTopologies) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(noderesourcetopologiesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(noderesourcetopologiesResource, opts))
 }
 
 // Create takes the representation of a nodeResourceTopology and creates it.  Returns the server's representation of the nodeResourceTopology, and an error, if there is any.
 func (c *FakeNodeResourceTopologies) Create(ctx context.Context, nodeResourceTopology *v1alpha1.NodeResourceTopology, opts v1.CreateOptions) (result *v1alpha1.NodeResourceTopology, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(noderesourcetopologiesResource, c.ns, nodeResourceTopology), &v1alpha1.NodeResourceTopology{})
-
+		Invokes(testing.NewRootCreateAction(noderesourcetopologiesResource, nodeResourceTopology), &v1alpha1.NodeResourceTopology{})
 	if obj == nil {
 		return nil, err
 	}
@@ -96,8 +91,7 @@ func (c *FakeNodeResourceTopologies) Create(ctx context.Context, nodeResourceTop
 // Update takes the representation of a nodeResourceTopology and updates it. Returns the server's representation of the nodeResourceTopology, and an error, if there is any.
 func (c *FakeNodeResourceTopologies) Update(ctx context.Context, nodeResourceTopology *v1alpha1.NodeResourceTopology, opts v1.UpdateOptions) (result *v1alpha1.NodeResourceTopology, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(noderesourcetopologiesResource, c.ns, nodeResourceTopology), &v1alpha1.NodeResourceTopology{})
-
+		Invokes(testing.NewRootUpdateAction(noderesourcetopologiesResource, nodeResourceTopology), &v1alpha1.NodeResourceTopology{})
 	if obj == nil {
 		return nil, err
 	}
@@ -107,14 +101,13 @@ func (c *FakeNodeResourceTopologies) Update(ctx context.Context, nodeResourceTop
 // Delete takes name of the nodeResourceTopology and deletes it. Returns an error if one occurs.
 func (c *FakeNodeResourceTopologies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(noderesourcetopologiesResource, c.ns, name), &v1alpha1.NodeResourceTopology{})
-
+		Invokes(testing.NewRootDeleteAction(noderesourcetopologiesResource, name), &v1alpha1.NodeResourceTopology{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeNodeResourceTopologies) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(noderesourcetopologiesResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(noderesourcetopologiesResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.NodeResourceTopologyList{})
 	return err
@@ -123,8 +116,7 @@ func (c *FakeNodeResourceTopologies) DeleteCollection(ctx context.Context, opts 
 // Patch applies the patch and returns the patched nodeResourceTopology.
 func (c *FakeNodeResourceTopologies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.NodeResourceTopology, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(noderesourcetopologiesResource, c.ns, name, pt, data, subresources...), &v1alpha1.NodeResourceTopology{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(noderesourcetopologiesResource, name, pt, data, subresources...), &v1alpha1.NodeResourceTopology{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/generated/clientset/versioned/typed/topology/v1alpha1/fake/fake_topology_client.go
+++ b/pkg/generated/clientset/versioned/typed/topology/v1alpha1/fake/fake_topology_client.go
@@ -30,8 +30,8 @@ type FakeTopologyV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeTopologyV1alpha1) NodeResourceTopologies(namespace string) v1alpha1.NodeResourceTopologyInterface {
-	return &FakeNodeResourceTopologies{c, namespace}
+func (c *FakeTopologyV1alpha1) NodeResourceTopologies() v1alpha1.NodeResourceTopologyInterface {
+	return &FakeNodeResourceTopologies{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/generated/clientset/versioned/typed/topology/v1alpha1/noderesourcetopology.go
+++ b/pkg/generated/clientset/versioned/typed/topology/v1alpha1/noderesourcetopology.go
@@ -35,7 +35,7 @@ import (
 // NodeResourceTopologiesGetter has a method to return a NodeResourceTopologyInterface.
 // A group's client should implement this interface.
 type NodeResourceTopologiesGetter interface {
-	NodeResourceTopologies(namespace string) NodeResourceTopologyInterface
+	NodeResourceTopologies() NodeResourceTopologyInterface
 }
 
 // NodeResourceTopologyInterface has methods to work with NodeResourceTopology resources.
@@ -54,14 +54,12 @@ type NodeResourceTopologyInterface interface {
 // nodeResourceTopologies implements NodeResourceTopologyInterface
 type nodeResourceTopologies struct {
 	client rest.Interface
-	ns     string
 }
 
 // newNodeResourceTopologies returns a NodeResourceTopologies
-func newNodeResourceTopologies(c *TopologyV1alpha1Client, namespace string) *nodeResourceTopologies {
+func newNodeResourceTopologies(c *TopologyV1alpha1Client) *nodeResourceTopologies {
 	return &nodeResourceTopologies{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -69,7 +67,6 @@ func newNodeResourceTopologies(c *TopologyV1alpha1Client, namespace string) *nod
 func (c *nodeResourceTopologies) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.NodeResourceTopology, err error) {
 	result = &v1alpha1.NodeResourceTopology{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("noderesourcetopologies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,7 +83,6 @@ func (c *nodeResourceTopologies) List(ctx context.Context, opts v1.ListOptions) 
 	}
 	result = &v1alpha1.NodeResourceTopologyList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("noderesourcetopologies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,7 +99,6 @@ func (c *nodeResourceTopologies) Watch(ctx context.Context, opts v1.ListOptions)
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("noderesourcetopologies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,7 +109,6 @@ func (c *nodeResourceTopologies) Watch(ctx context.Context, opts v1.ListOptions)
 func (c *nodeResourceTopologies) Create(ctx context.Context, nodeResourceTopology *v1alpha1.NodeResourceTopology, opts v1.CreateOptions) (result *v1alpha1.NodeResourceTopology, err error) {
 	result = &v1alpha1.NodeResourceTopology{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("noderesourcetopologies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(nodeResourceTopology).
@@ -127,7 +121,6 @@ func (c *nodeResourceTopologies) Create(ctx context.Context, nodeResourceTopolog
 func (c *nodeResourceTopologies) Update(ctx context.Context, nodeResourceTopology *v1alpha1.NodeResourceTopology, opts v1.UpdateOptions) (result *v1alpha1.NodeResourceTopology, err error) {
 	result = &v1alpha1.NodeResourceTopology{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("noderesourcetopologies").
 		Name(nodeResourceTopology.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -140,7 +133,6 @@ func (c *nodeResourceTopologies) Update(ctx context.Context, nodeResourceTopolog
 // Delete takes name of the nodeResourceTopology and deletes it. Returns an error if one occurs.
 func (c *nodeResourceTopologies) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("noderesourcetopologies").
 		Name(name).
 		Body(&opts).
@@ -155,7 +147,6 @@ func (c *nodeResourceTopologies) DeleteCollection(ctx context.Context, opts v1.D
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("noderesourcetopologies").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -168,7 +159,6 @@ func (c *nodeResourceTopologies) DeleteCollection(ctx context.Context, opts v1.D
 func (c *nodeResourceTopologies) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.NodeResourceTopology, err error) {
 	result = &v1alpha1.NodeResourceTopology{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("noderesourcetopologies").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/generated/clientset/versioned/typed/topology/v1alpha1/topology_client.go
+++ b/pkg/generated/clientset/versioned/typed/topology/v1alpha1/topology_client.go
@@ -36,8 +36,8 @@ type TopologyV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *TopologyV1alpha1Client) NodeResourceTopologies(namespace string) NodeResourceTopologyInterface {
-	return newNodeResourceTopologies(c, namespace)
+func (c *TopologyV1alpha1Client) NodeResourceTopologies() NodeResourceTopologyInterface {
+	return newNodeResourceTopologies(c)
 }
 
 // NewForConfig creates a new TopologyV1alpha1Client for the given config.

--- a/pkg/generated/informers/externalversions/topology/v1alpha1/interface.go
+++ b/pkg/generated/informers/externalversions/topology/v1alpha1/interface.go
@@ -43,5 +43,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // NodeResourceTopologies returns a NodeResourceTopologyInformer.
 func (v *version) NodeResourceTopologies() NodeResourceTopologyInformer {
-	return &nodeResourceTopologyInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &nodeResourceTopologyInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/generated/informers/externalversions/topology/v1alpha1/noderesourcetopology.go
+++ b/pkg/generated/informers/externalversions/topology/v1alpha1/noderesourcetopology.go
@@ -44,33 +44,32 @@ type NodeResourceTopologyInformer interface {
 type nodeResourceTopologyInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewNodeResourceTopologyInformer constructs a new informer for NodeResourceTopology type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewNodeResourceTopologyInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredNodeResourceTopologyInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewNodeResourceTopologyInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredNodeResourceTopologyInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredNodeResourceTopologyInformer constructs a new informer for NodeResourceTopology type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredNodeResourceTopologyInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredNodeResourceTopologyInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.TopologyV1alpha1().NodeResourceTopologies(namespace).List(context.TODO(), options)
+				return client.TopologyV1alpha1().NodeResourceTopologies().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.TopologyV1alpha1().NodeResourceTopologies(namespace).Watch(context.TODO(), options)
+				return client.TopologyV1alpha1().NodeResourceTopologies().Watch(context.TODO(), options)
 			},
 		},
 		&topologyv1alpha1.NodeResourceTopology{},
@@ -80,7 +79,7 @@ func NewFilteredNodeResourceTopologyInformer(client versioned.Interface, namespa
 }
 
 func (f *nodeResourceTopologyInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredNodeResourceTopologyInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredNodeResourceTopologyInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *nodeResourceTopologyInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/generated/listers/topology/v1alpha1/expansion_generated.go
+++ b/pkg/generated/listers/topology/v1alpha1/expansion_generated.go
@@ -23,7 +23,3 @@ package v1alpha1
 // NodeResourceTopologyListerExpansion allows custom methods to be added to
 // NodeResourceTopologyLister.
 type NodeResourceTopologyListerExpansion interface{}
-
-// NodeResourceTopologyNamespaceListerExpansion allows custom methods to be added to
-// NodeResourceTopologyNamespaceLister.
-type NodeResourceTopologyNamespaceListerExpansion interface{}

--- a/pkg/generated/listers/topology/v1alpha1/noderesourcetopology.go
+++ b/pkg/generated/listers/topology/v1alpha1/noderesourcetopology.go
@@ -33,8 +33,9 @@ type NodeResourceTopologyLister interface {
 	// List lists all NodeResourceTopologies in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.NodeResourceTopology, err error)
-	// NodeResourceTopologies returns an object that can list and get NodeResourceTopologies.
-	NodeResourceTopologies(namespace string) NodeResourceTopologyNamespaceLister
+	// Get retrieves the NodeResourceTopology from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.NodeResourceTopology, error)
 	NodeResourceTopologyListerExpansion
 }
 
@@ -56,41 +57,9 @@ func (s *nodeResourceTopologyLister) List(selector labels.Selector) (ret []*v1al
 	return ret, err
 }
 
-// NodeResourceTopologies returns an object that can list and get NodeResourceTopologies.
-func (s *nodeResourceTopologyLister) NodeResourceTopologies(namespace string) NodeResourceTopologyNamespaceLister {
-	return nodeResourceTopologyNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// NodeResourceTopologyNamespaceLister helps list and get NodeResourceTopologies.
-// All objects returned here must be treated as read-only.
-type NodeResourceTopologyNamespaceLister interface {
-	// List lists all NodeResourceTopologies in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.NodeResourceTopology, err error)
-	// Get retrieves the NodeResourceTopology from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.NodeResourceTopology, error)
-	NodeResourceTopologyNamespaceListerExpansion
-}
-
-// nodeResourceTopologyNamespaceLister implements the NodeResourceTopologyNamespaceLister
-// interface.
-type nodeResourceTopologyNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all NodeResourceTopologies in the indexer for a given namespace.
-func (s nodeResourceTopologyNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.NodeResourceTopology, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.NodeResourceTopology))
-	})
-	return ret, err
-}
-
-// Get retrieves the NodeResourceTopology from the indexer for a given namespace and name.
-func (s nodeResourceTopologyNamespaceLister) Get(name string) (*v1alpha1.NodeResourceTopology, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the NodeResourceTopology from the index for a given name.
+func (s *nodeResourceTopologyLister) Get(name string) (*v1alpha1.NodeResourceTopology, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When moving to cluster scoped, unfortunately a typo in the changed tag and a missing new tag prevented the autogeneration to work as expected. This PR addresses and fixes.
Tested using: https://github.com/k8stopologyawareschedwg/resource-topology-exporter/pull/74