### PR TITLE
Add missing TopologyManagerPolicies

### DIFF
--- a/pkg/apis/topology/v1alpha1/types.go
+++ b/pkg/apis/topology/v1alpha1/types.go
@@ -19,8 +19,16 @@ const (
 	SingleNUMANodePodLevel TopologyManagerPolicy = "SingleNUMANodePodLevel"
 	// Restricted TopologyManager policy was set on the node
 	Restricted TopologyManagerPolicy = "Restricted"
+	// RestrictedContainerLevel TopologyManager policy was set on the node and TopologyManagerScope was set to pod
+	RestrictedContainerLevel TopologyManagerPolicy = "RestrictedContainerLevel"
+	// RestrictedPodLevel TopologyManager policy was set on the node and TopologyManagerScope was set to pod
+	RestrictedPodLevel TopologyManagerPolicy = "RestrictedPodLevel"
 	// BestEffort TopologyManager policy was set on the node
 	BestEffort TopologyManagerPolicy = "BestEffort"
+	// BestEffort TopologyManager policy was set on the node and TopologyManagerScope was set to container
+	BestEffortContainerLevel TopologyManagerPolicy = "BestEffortContainerLevel"
+	// BestEffort TopologyManager policy was set on the node and TopologyManagerScope was set to pod
+	BestEffortPodLevel TopologyManagerPolicy = "BestEffortPodLevel"
 	// None policy is the default policy and does not perform any topology alignment.
 	None TopologyManagerPolicy = "None"
 )


### PR DESCRIPTION
Adding missing TopologyManagerPolicies as per discussion in https://github.com/k8stopologyawareschedwg/noderesourcetopology-api/issues/21