### PR TITLE
crd: regenerate with v1alpha2

### DIFF
--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1870
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: noderesourcetopologies.topology.node.k8s.io
 spec:
@@ -134,10 +134,137 @@ spec:
         - zones
         type: object
     served: true
+    storage: false
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: NodeResourceTopology describes node resources and their topology.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          attributes:
+            description: AttributeList contains an array of AttributeInfo objects.
+            items:
+              description: AttributeInfo contains one attribute of a Zone.
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+              required:
+              - name
+              - value
+              type: object
+            type: array
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          topologyPolicies:
+            description: 'DEPRECATED (to be removed in v1beta1): use top level attributes
+              if needed'
+            items:
+              type: string
+            type: array
+          zones:
+            description: ZoneList contains an array of Zone objects.
+            items:
+              description: Zone represents a resource topology zone, e.g. socket,
+                node, die or core.
+              properties:
+                attributes:
+                  description: AttributeList contains an array of AttributeInfo objects.
+                  items:
+                    description: AttributeInfo contains one attribute of a Zone.
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                costs:
+                  description: CostList contains an array of CostInfo objects.
+                  items:
+                    description: CostInfo describes the cost (or distance) between
+                      two Zones.
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        format: int64
+                        type: integer
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                name:
+                  type: string
+                parent:
+                  type: string
+                resources:
+                  description: ResourceInfoList contains an array of ResourceInfo
+                    objects.
+                  items:
+                    description: ResourceInfo contains information about one resource
+                      type.
+                    properties:
+                      allocatable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Allocatable quantity of the resource, corresponding
+                          to allocatable in node status, i.e. total amount of this
+                          resource available to be used by pods.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      available:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Available is the amount of this resource currently
+                          available for new (to be scheduled) pods, i.e. Allocatable
+                          minus the resources reserved by currently running pods.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      capacity:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Capacity of the resource, corresponding to capacity
+                          in node status, i.e. total amount of this resource that
+                          the node has.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      name:
+                        description: Name of the resource.
+                        type: string
+                    required:
+                    - allocatable
+                    - available
+                    - capacity
+                    - name
+                    type: object
+                  type: array
+                type:
+                  type: string
+              required:
+              - name
+              - type
+              type: object
+            type: array
+        required:
+        - zones
+        type: object
+    served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/apis/topology/v1alpha2/types.go
+++ b/pkg/apis/topology/v1alpha2/types.go
@@ -39,6 +39,7 @@ const (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster,shortName=node-res-topo
+// +kubebuilder:storageversion
 
 // NodeResourceTopology describes node resources and their topology.
 type NodeResourceTopology struct {

--- a/pkg/apis/topology/v1alpha2/types.go
+++ b/pkg/apis/topology/v1alpha2/types.go
@@ -46,7 +46,7 @@ type NodeResourceTopology struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// DEPRECATED (to be removed in v1beta1): use top level attributes if needed
-	TopologyPolicies []string `json:"topologyPolicies"`
+	TopologyPolicies []string `json:"topologyPolicies,omitempty"`
 
 	Zones      ZoneList      `json:"zones"`
 	Attributes AttributeList `json:"attributes,omitempty"`


### PR DESCRIPTION
Followup to #25 regenerate the CRD including v1alpha2.

We will evaluate if we want to also offer version-specific CRDs alongside the all-in-one `manifests/crd.yaml`.