### PR TITLE
crd: generator: add api-approved annotation

### DIFF
--- a/hack/update-crd.sh
+++ b/hack/update-crd.sh
@@ -18,13 +18,5 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-controller-gen object crd output:crd:dir=. paths=./pkg/apis/...
+controller-gen object crd output:crd:stdout paths=./pkg/apis/... > manifests/crd.yaml
 
-kubectl annotate --overwrite \
-                 --local=true \
-                 -o yaml \
-                 -f topology.node.k8s.io_noderesourcetopologies.yaml \
-                 "api-approved.kubernetes.io=https://github.com/kubernetes/enhancements/pull/1870" \
-                 > manifests/crd.yaml
-
-rm topology.node.k8s.io_noderesourcetopologies.yaml

--- a/pkg/apis/topology/v1alpha1/types.go
+++ b/pkg/apis/topology/v1alpha1/types.go
@@ -37,6 +37,7 @@ const (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster,shortName=node-res-topo
+// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes/enhancements/pull/1870"
 
 // NodeResourceTopology describes node resources and their topology.
 type NodeResourceTopology struct {

--- a/pkg/apis/topology/v1alpha2/types.go
+++ b/pkg/apis/topology/v1alpha2/types.go
@@ -39,6 +39,7 @@ const (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster,shortName=node-res-topo
+// +kubebuilder:metadata:annotations="api-approved.kubernetes.io=https://github.com/kubernetes/enhancements/pull/1870"
 // +kubebuilder:storageversion
 
 // NodeResourceTopology describes node resources and their topology.


### PR DESCRIPTION
Instead of adding the api-approved label (needed by at least envtest to work properly) during the post-processing stage in our `update-crd.sh` script, let's add the kubebuilder tags and let's let controller-gen do the work for us.

This greatly improves compatibility when integrating with external projects which can't (or shouldn't) use our script.

Signed-off-by: Francesco Romani <fromani@redhat.com>