### PR TITLE
api: helper: add the numanode helper package

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version-file: go.mod
 
     - name: Vet
       run: make vet

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,48 @@ require (
 	k8s.io/code-generator v0.22.3
 )
 
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	golang.org/x/tools v0.1.2 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/api v0.22.3 // indirect
+	k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 // indirect
+	k8s.io/klog/v2 v2.9.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
+)
+
 replace github.com/k8stopologyawareschedwg/noderesourcetopology-api => ../noderesourcetopology-api

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8stopologyawareschedwg/noderesourcetopology-api
 
-go 1.16
+go 1.20
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/pkg/apis/topology/v1alpha2/helper/helper.go
+++ b/pkg/apis/topology/v1alpha2/helper/helper.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+// known zone types
+const (
+	// NUMA Node. Synonyms: NUMA zone, NUMA cell...
+	ZoneTypeNUMANode string = "Node"
+)

--- a/pkg/apis/topology/v1alpha2/helper/numanode/numanode.go
+++ b/pkg/apis/topology/v1alpha2/helper/numanode/numanode.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package numanode
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	canonicalPrefix = "node-"
+)
+
+// IDToName creates the canonical NUMA node name given the NUMA cell ID
+func IDToName(numaID int) (string, error) {
+	if numaID < 0 {
+		return "", fmt.Errorf("invalid NUMA id range numaID: %d", numaID)
+	}
+	return canonicalPrefix + strconv.Itoa(numaID), nil
+}
+
+// NameToID retrieves the NUMA cell ID (integer) from the canonical
+// NUMA node name (node-X, cell ID would be X).
+func NameToID(node string) (int, error) {
+	numaIDStr, ok := strings.CutPrefix(node, canonicalPrefix)
+	if !ok {
+		return -1, fmt.Errorf("invalid format for name %q: bad prefix", node)
+	}
+	numaID, err := strconv.Atoi(numaIDStr)
+	if err != nil {
+		return -1, fmt.Errorf("invalid format for name %q: %v", node, err)
+	}
+	if numaID < 0 {
+		return -1, fmt.Errorf("invalid format for name %q: bad NUMA id: %d", node, numaID)
+	}
+	return numaID, nil
+}

--- a/pkg/apis/topology/v1alpha2/helper/numanode/numanode_test.go
+++ b/pkg/apis/topology/v1alpha2/helper/numanode/numanode_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package numanode
+
+import (
+	"testing"
+)
+
+func TestIDToName(t *testing.T) {
+	testCases := []struct {
+		name          string
+		cellID        int
+		expected      string
+		expectedError bool
+	}{
+		{
+			name:     "zero",
+			cellID:   0,
+			expected: "node-0",
+		},
+		{
+			name:     "positive",
+			cellID:   7,
+			expected: "node-7",
+		},
+		{
+			name:     "excessive",
+			cellID:   65535,
+			expected: "node-65535",
+		},
+		{
+			name:          "negative",
+			cellID:        -1,
+			expected:      "",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IDToName(tt.cellID)
+			gotErr := (err != nil)
+			if gotErr != tt.expectedError {
+				t.Fatalf("expected error=%v got=%v", tt.expectedError, gotErr)
+			}
+			if got != tt.expected {
+				t.Fatalf("expected value %v got value %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestNameToID(t *testing.T) {
+	testCases := []struct {
+		name          string
+		cellName      string
+		expected      int
+		expectedError bool
+	}{
+		{
+			name:     "zero",
+			cellName: "node-0",
+			expected: 0,
+		},
+		{
+			name:     "positive",
+			cellName: "node-7",
+			expected: 7,
+		},
+		{
+			name:     "excessive",
+			cellName: "node-65535",
+			expected: 65535,
+		},
+		{
+			name:          "negative",
+			cellName:      "node--1",
+			expected:      -1,
+			expectedError: true,
+		},
+		{
+			name:          "wrong node id",
+			cellName:      "cell-1",
+			expected:      -1,
+			expectedError: true,
+		},
+		{
+			name:          "case node id (1)",
+			cellName:      "Node-1",
+			expected:      -1,
+			expectedError: true,
+		},
+		{
+			name:          "case node id (2)",
+			cellName:      "NODE-2",
+			expected:      -1,
+			expectedError: true,
+		},
+		{
+			name:          "case node id (3)",
+			cellName:      "node_3",
+			expected:      -1,
+			expectedError: true,
+		},
+		{
+			name:          "case node id (4)",
+			cellName:      "node 4",
+			expected:      -1,
+			expectedError: true,
+		},
+		{
+			name:          "case node id (5)",
+			cellName:      "node-5-1",
+			expected:      -1,
+			expectedError: true,
+		},
+		{
+			name:          "case node id (6)",
+			cellName:      "node6",
+			expected:      -1,
+			expectedError: true,
+		},
+		{
+			name:          "case node id (7)",
+			cellName:      "--node-7",
+			expected:      -1,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NameToID(tt.cellName)
+			gotErr := (err != nil)
+			if gotErr != tt.expectedError {
+				t.Fatalf("expected error=%v got=%v", tt.expectedError, gotErr)
+			}
+			if got != tt.expected {
+				t.Fatalf("expected value %v got value %v", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a package to consolidate common usage of Zones as NUMA Nodes. This encapsulate patterns commonly seen in the consumer code. Since no better or cleaner approach emerged, and until it does, better to cleanup and centralize this code.