### PR TITLE
ghactions: update actions

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -11,12 +11,12 @@ jobs:
   code-checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Set up golang
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.19
 


### PR DESCRIPTION
we were stuck on old and deprecated v2 for no good reason. Bump to v5 and get rid of the deprecation warnings.